### PR TITLE
Add matchday overview page with trainer photos

### DIFF
--- a/combates.html
+++ b/combates.html
@@ -159,175 +159,149 @@
 
 <nav id="main-nav"></nav>
 
-<div class="combates-container">
-  <h1 style="text-align:center; color:var(--secondary); margin-bottom:2rem;">🎥 Combats per Jornada</h1>
-  <!-- Jornada 1 -->
-  <div class="jornada">
-    <div class="jornada-header">Jornada 1 - Inici de Temporada</div>
-    <div class="combates-grid">
-      <!-- Combate 1 -->
-      <div class="combate-card" data-muertes="Rockruff(Eudald) 💀 Sudowoodo(Jordi); Charcadet(Eudald) 💀 Corvisquire(Jordi); Diglett(Eudald) 💀 Fidough(Jordi); Fidough(Jordi) 💀 Gulpin(Eudald); Chansey(Jordi) 💀 Pawmo(Eudald); Fletchinder(Jordi) 💀 Gulpin(Eudald); Gulpin(Eudald) 💀 Luxio(Jordi); Luxio(Jordi) 💀 Floragato(Eudald); Floragato(Eudald) 💀 Corvisquire(Jordi); Corvisquire(Jordi) 💀 Pawmo(Eudald); Sudowoodo(Jordi) 💀 Pawmo(Eudald)">
-        <div class="combate-video">
-          <iframe src="https://www.youtube.com/embed/UojOkKS5GD8" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        <div class="combate-info">
-          <h3>Jordi vs Eudald</h3>
-          <div class="participantes">
-            <span>Jordi</span>
-            <span class="ganador">Eudald (Guanyador)</span>
-          </div>
-          <div class="combate-meta">
-            <span>06/07/2025</span>
-            <span>⏱️ 22:00</span>
-          </div>
-        </div>
-      </div>
-      <!-- Combate 2 -->
-      <div class="combate-card" data-muertes="Oinkologne(Josep) 💀 Sudowoodo(Jordi); Sudowoodo(Jordi) 💀 Toedscool(Josep); Fidough(Jordi) 💀 Skiploom(Josep); Chansey(Jordi) 💀 Pawmo(Josep); Corvisquire(Jordi) 💀 Crocalor(Josep); Toedscool(Josep) 💀 Luxio(Jordi); Kricketune(Josep) 💀 Luxio(Jordi); Crocalor(Josep) 💀 Luxio(Jordi)">
-        <div class="combate-video">
-          <iframe src="https://www.youtube.com/embed/CXq6x19AvyY" allowfullscreen></iframe>
-        </div>
-        <div class="combate-info">
-          <h3>Jordi vs Josep</h3>
-          <div class="participantes">
-            <span class="ganador">Jordi (Guanyador)</span>
-            <span>Josep</span>
-          </div>
-          <div class="combate-meta">
-            <span>06/07/2025</span>
-            <span>⏱️ 22:30</span>
-          </div>
-        </div>
-      </div>
-      <!-- Combate 3 -->
-      <div class="combate-card" data-muertes="Rockruff (Eudald) 💀 Oinkologne(Josep); Psyduck(Eudald) 💀 Oinkologne(Josep); Oinkologne(Josep) 💀 Floragato(Eudald); Toedscool(Josep) 💀 Skiploom(Eudald); Kircketune(Josep) 💀 Floragato(Eudald); Floragato(Eudald) 💀 Crocalor(Josep); Pawmo(Eudald) 💀 Crocalor(Josep); Crocalor(Josep) 💀 Skiploom(Eudald);">
-        <div class="combate-video">
-          <iframe src="https://www.youtube.com/embed/J1sCcv2xzHU" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        <div class="combate-info">
-          <h3>Josep vs Eudald</h3>
-          <div class="participantes">
-            <span>Josep</span>
-            <span>Eudald</span>
-          </div>
-          <div class="combate-meta">
-            <span>06/07/2025</span>
-            <span>⏱️ 23:00</span>
-          </div>
-        </div>
-      </div>
+  <div class="combates-container">
+    <h1 style="text-align:center; color:var(--secondary); margin-bottom:2rem;">🎥 Combats per Jornada</h1>
+    <div id="jornades-container"></div>
+  </div>
+
+  <!-- Modal -->
+  <div id="modal" class="modal">
+    <div class="modal-content">
+      <span class="close-btn">&times;</span>
+      <h2>Detalls del combat</h2>
+      <h3>Muertes</h3>
+      <ul id="muertes-list"></ul>
+      <h3>Equips</h3>
+      <p id="equips-info"></p>
+      <h3>Bans</h3>
+      <p id="bans-info"></p>
+      <a id="youtube-link" href="#" target="_blank">Ver en YouTube</a>
     </div>
   </div>
-  <!-- Jornada 2 -->
-  <div class="jornada">
-    <div class="jornada-header">Jornada 2 </div>
-    <div class="combates-grid">
-      <!-- Combate 1 -->
-      <div class="combate-card" data-muertes="Rockruff(Eudald) 💀 Sudowoodo(Jordi); Charcadet(Eudald) 💀 Corvisquire(Jordi); Diglett(Eudald) 💀 Fidough(Jordi); Fidough(Jordi) 💀 Gulpin(Eudald); Chansey(Jordi) 💀 Pawmo(Eudald); Fletchinder(Jordi) 💀 Gulpin(Eudald); Gulpin(Eudald) 💀 Luxio(Jordi); Luxio(Jordi) 💀 Floragato(Eudald); Floragato(Eudald) 💀 Corvisquire(Jordi); Corvisquire(Jordi) 💀 Pawmo(Eudald); Sudowoodo(Jordi) 💀 Pawmo(Eudald)">
-        <div class="combate-video">
-          <iframe src="https://www.youtube.com/embed/wzYC9wzwvyU" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        <div class="combate-info">
-          <h3>Jordi vs Josep</h3>
-          <div class="participantes">
-            <span>Jordi</span>
-            <span class="ganador">Josep (Guanyador)</span>
-          </div>
-          <div class="combate-meta">
-            <span>13/07/2025</span>
-            <span>⏱️ 22:30</span>
-          </div>
-        </div>
-      </div>
-      <!-- Combate 2 -->
-      <div class="combate-card" data-muertes="Oinkologne(Josep) 💀 Sudowoodo(Jordi); Sudowoodo(Jordi) 💀 Toedscool(Josep); Fidough(Jordi) 💀 Skiploom(Josep); Chansey(Jordi) 💀 Pawmo(Josep); Corvisquire(Jordi) 💀 Crocalor(Josep); Toedscool(Josep) 💀 Luxio(Jordi); Kricketune(Josep) 💀 Luxio(Jordi); Crocalor(Josep) 💀 Luxio(Jordi)">
-        <div class="combate-video">
-          <iframe src="https://www.youtube.com/embed/GcLunYRxzYo" allowfullscreen></iframe>
-        </div>
-        <div class="combate-info">
-          <h3>Eudald vs Josep</h3>
-          <div class="participantes">
-            <span class="ganador">Josep (Guanyador)</span>
-            <span>Eudald</span>
-          </div>
-          <div class="combate-meta">
-            <span>13/07/2025</span>
-            <span>⏱️ 23:00</span>
-          </div>
-        </div>
-      </div>
-      <!-- Combate 3 -->
-      <div class="combate-card" data-muertes="Rockruff (Eudald) 💀 Oinkologne(Josep); Psyduck(Eudald) 💀 Oinkologne(Josep); Oinkologne(Josep) 💀 Floragato(Eudald); Toedscool(Josep) 💀 Skiploom(Eudald); Kircketune(Josep) 💀 Floragato(Eudald); Floragato(Eudald) 💀 Crocalor(Josep); Pawmo(Eudald) 💀 Crocalor(Josep); Crocalor(Josep) 💀 Skiploom(Eudald);">
-        <div class="combate-video">
-          <iframe src="https://www.youtube.com/embed/6uAHdV7UEXw" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        <div class="combate-info">
-          <h3>Jordi vs Eudald</h3>
-          <div class="participantes">
-            <span class="ganador">Eudald (Guanyador)</span>
-            <span>Jordi</span>
-          </div>
-          <div class="combate-meta">
-            <span>13/07/2025</span>
-            <span>⏱️ 23:30</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Más jornadas según necesites -->
-</div>
 
-<!-- Modal -->
-<div id="modal" class="modal">
-  <div class="modal-content">
-    <span class="close-btn">&times;</span>
-    <h2>Muertes</h2>
-    <ul id="muertes-list"></ul>
-    <a id="youtube-link" href="#" target="_blank">Ver en YouTube</a>
-  </div>
-</div>
+  <script>
+  async function loadCombats() {
+    const response = await fetch('data/jornades.json');
+    const data = await response.json();
+    const container = document.getElementById('jornades-container');
+    data.jornades.forEach(jornada => {
+      const jornadaDiv = document.createElement('div');
+      jornadaDiv.className = 'jornada';
+      const header = document.createElement('div');
+      header.className = 'jornada-header';
+      header.textContent = `Jornada ${jornada.numero}${jornada.nom ? ' - ' + jornada.nom : ''}`;
+      jornadaDiv.appendChild(header);
+      const grid = document.createElement('div');
+      grid.className = 'combates-grid';
+      jornada.combats.forEach(combat => {
+        const card = document.createElement('div');
+        card.className = 'combate-card';
+        card.dataset.muertes = (combat.muertes || []).join('; ');
+        card.dataset.equips = JSON.stringify(combat.equips || {});
+        card.dataset.bans = JSON.stringify(combat.bans || {});
 
-<script>
-// Abre el modal al hacer clic en el título del combate
-const titles = document.querySelectorAll('.combate-info h3');
-const modal = document.getElementById('modal');
-const muertesList = document.getElementById('muertes-list');
-const youtubeLink = document.getElementById('youtube-link');
+        const videoDiv = document.createElement('div');
+        videoDiv.className = 'combate-video';
+        const iframe = document.createElement('iframe');
+        iframe.src = combat.youtube;
+        iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+        iframe.allowFullscreen = true;
+        videoDiv.appendChild(iframe);
+        card.appendChild(videoDiv);
 
-titles.forEach(title => {
-  title.addEventListener('click', (e) => {
-    const card = e.target.closest('.combate-card');
-    const muertesData = (card.dataset.muertes || '').split(';');
-    muertesList.innerHTML = '';
-    muertesData.forEach(item => {
-      const li = document.createElement('li');
-      li.textContent = item.trim();
-      muertesList.appendChild(li);
+        const infoDiv = document.createElement('div');
+        infoDiv.className = 'combate-info';
+        const title = document.createElement('h3');
+        title.textContent = `${combat.jugador1} vs ${combat.jugador2}`;
+        infoDiv.appendChild(title);
+
+        const participantes = document.createElement('div');
+        participantes.className = 'participantes';
+        const p1 = document.createElement('span');
+        p1.textContent = combat.jugador1;
+        const p2 = document.createElement('span');
+        p2.textContent = combat.jugador2;
+        if (combat.guanyador === combat.jugador1) {
+          p1.classList.add('ganador');
+          p1.textContent += ' (Guanyador)';
+        }
+        if (combat.guanyador === combat.jugador2) {
+          p2.classList.add('ganador');
+          p2.textContent += ' (Guanyador)';
+        }
+        participantes.appendChild(p1);
+        participantes.appendChild(p2);
+        infoDiv.appendChild(participantes);
+
+        const meta = document.createElement('div');
+        meta.className = 'combate-meta';
+        const dateSpan = document.createElement('span');
+        dateSpan.textContent = combat.data;
+        const timeSpan = document.createElement('span');
+        timeSpan.textContent = `⏱️ ${combat.hora}`;
+        meta.appendChild(dateSpan);
+        meta.appendChild(timeSpan);
+        infoDiv.appendChild(meta);
+
+        card.appendChild(infoDiv);
+        grid.appendChild(card);
+      });
+      jornadaDiv.appendChild(grid);
+      container.appendChild(jornadaDiv);
     });
-    // Convierte la URL del iframe en enlace a YouTube
-    const iframe = card.querySelector('iframe');
-    if (iframe) {
-      const src = iframe.src;
-      // Reemplaza "embed/" por "watch?v=" para enlace normal
-      const normalUrl = src.replace('embed/', 'watch?v=');
-      youtubeLink.href = normalUrl;
-    }
-    modal.style.display = 'flex';
-  });
-});
-
-// Cerrar modal
-const closeBtn = document.querySelector('.close-btn');
-closeBtn.addEventListener('click', () => {
-  modal.style.display = 'none';
-});
-window.addEventListener('click', (e) => {
-  if (e.target === modal) {
-    modal.style.display = 'none';
+    attachModalHandlers();
   }
-});
-</script>
+
+  function attachModalHandlers() {
+    const titles = document.querySelectorAll('.combate-info h3');
+    const modal = document.getElementById('modal');
+    const muertesList = document.getElementById('muertes-list');
+    const equipsInfo = document.getElementById('equips-info');
+    const bansInfo = document.getElementById('bans-info');
+    const youtubeLink = document.getElementById('youtube-link');
+
+    titles.forEach(title => {
+      title.addEventListener('click', (e) => {
+        const card = e.target.closest('.combate-card');
+        const muertesData = (card.dataset.muertes || '').split(';');
+        muertesList.innerHTML = '';
+        muertesData.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = item.trim();
+          muertesList.appendChild(li);
+        });
+        const equipsData = JSON.parse(card.dataset.equips || '{}');
+        equipsInfo.textContent = Object.entries(equipsData)
+          .map(([trainer, team]) => `${trainer}: ${team.join(', ')}`)
+          .join(' | ');
+        const bansData = JSON.parse(card.dataset.bans || '{}');
+        const bansText = Object.entries(bansData)
+          .map(([trainer, bans]) => `${trainer}: ${bans.join(', ')}`)
+          .join(' | ');
+        bansInfo.textContent = bansText ? `Bans: ${bansText}` : '';
+        const iframe = card.querySelector('iframe');
+        if (iframe) {
+          const src = iframe.src;
+          const normalUrl = src.replace('embed/', 'watch?v=');
+          youtubeLink.href = normalUrl;
+        }
+        modal.style.display = 'flex';
+      });
+    });
+
+    const closeBtn = document.querySelector('.close-btn');
+    closeBtn.addEventListener('click', () => {
+      modal.style.display = 'none';
+    });
+    window.addEventListener('click', (e) => {
+      if (e.target === modal) {
+        modal.style.display = 'none';
+      }
+    });
+  }
+
+  loadCombats();
+  </script>
 <script type="module">
     import { setupNav } from './nav-component.js';
     document.addEventListener('DOMContentLoaded', setupNav);

--- a/data/jornades.json
+++ b/data/jornades.json
@@ -1,0 +1,178 @@
+{
+  "jornades": [
+    {
+      "numero": 1,
+      "nom": "Inici de Temporada",
+      "combats": [
+        {
+          "jugador1": "Jordi",
+          "jugador2": "Eudald",
+          "guanyador": "Eudald",
+          "data": "06/07/2025",
+          "hora": "22:00",
+          "youtube": "https://www.youtube.com/embed/UojOkKS5GD8",
+          "equips": {
+            "Jordi": ["Sudowoodo","Corvisquire","Fidough","Chansey","Fletchinder","Luxio"],
+            "Eudald": ["Rockruff","Charcadet","Diglett","Gulpin","Pawmo","Floragato"]
+          },
+          "bans": {
+            "Jordi": ["Quaxwell"],
+            "Eudald": ["Sylveon"]
+          },
+          "muertes": [
+            "Rockruff(Eudald) 💀 Sudowoodo(Jordi)",
+            "Charcadet(Eudald) 💀 Corvisquire(Jordi)",
+            "Diglett(Eudald) 💀 Fidough(Jordi)",
+            "Fidough(Jordi) 💀 Gulpin(Eudald)",
+            "Chansey(Jordi) 💀 Pawmo(Eudald)",
+            "Fletchinder(Jordi) 💀 Gulpin(Eudald)",
+            "Gulpin(Eudald) 💀 Luxio(Jordi)",
+            "Luxio(Jordi) 💀 Floragato(Eudald)",
+            "Floragato(Eudald) 💀 Corvisquire(Jordi)",
+            "Corvisquire(Jordi) 💀 Pawmo(Eudald)",
+            "Sudowoodo(Jordi) 💀 Pawmo(Eudald)"
+          ]
+        },
+        {
+          "jugador1": "Jordi",
+          "jugador2": "Josep",
+          "guanyador": "Jordi",
+          "data": "06/07/2025",
+          "hora": "22:30",
+          "youtube": "https://www.youtube.com/embed/CXq6x19AvyY",
+          "equips": {
+            "Jordi": ["Sudowoodo","Fidough","Chansey","Corvisquire","Luxio"],
+            "Josep": ["Oinkologne","Toedscool","Skiploom","Pawmo","Crocalor","Kricketune"]
+          },
+          "bans": {
+            "Jordi": ["Quaxwell"],
+            "Josep": ["Espeon"]
+          },
+          "muertes": [
+            "Oinkologne(Josep) 💀 Sudowoodo(Jordi)",
+            "Sudowoodo(Jordi) 💀 Toedscool(Josep)",
+            "Fidough(Jordi) 💀 Skiploom(Josep)",
+            "Chansey(Jordi) 💀 Pawmo(Josep)",
+            "Corvisquire(Jordi) 💀 Crocalor(Josep)",
+            "Toedscool(Josep) 💀 Luxio(Jordi)",
+            "Kricketune(Josep) 💀 Luxio(Jordi)",
+            "Crocalor(Josep) 💀 Luxio(Jordi)"
+          ]
+        },
+        {
+          "jugador1": "Josep",
+          "jugador2": "Eudald",
+          "guanyador": null,
+          "data": "06/07/2025",
+          "hora": "23:00",
+          "youtube": "https://www.youtube.com/embed/J1sCcv2xzHU",
+          "equips": {
+            "Josep": ["Oinkologne","Toedscool","Kricketune","Crocalor"],
+            "Eudald": ["Rockruff","Psyduck","Floragato","Skiploom","Pawmo"]
+          },
+          "bans": {
+            "Josep": ["Espeon"],
+            "Eudald": ["Sylveon"]
+          },
+          "muertes": [
+            "Rockruff(Eudald) 💀 Oinkologne(Josep)",
+            "Psyduck(Eudald) 💀 Oinkologne(Josep)",
+            "Oinkologne(Josep) 💀 Floragato(Eudald)",
+            "Toedscool(Josep) 💀 Skiploom(Eudald)",
+            "Kircketune(Josep) 💀 Floragato(Eudald)",
+            "Floragato(Eudald) 💀 Crocalor(Josep)",
+            "Pawmo(Eudald) 💀 Crocalor(Josep)",
+            "Crocalor(Josep) 💀 Skiploom(Eudald)"
+          ]
+        }
+      ]
+    },
+    {
+      "numero": 2,
+      "nom": "",
+      "combats": [
+        {
+          "jugador1": "Jordi",
+          "jugador2": "Josep",
+          "guanyador": "Josep",
+          "data": "13/07/2025",
+          "hora": "22:30",
+          "youtube": "https://www.youtube.com/embed/wzYC9wzwvyU",
+          "equips": {
+            "Jordi": ["Sudowoodo","Corvisquire","Fidough","Chansey","Fletchinder","Luxio"],
+            "Josep": ["Rockruff","Charcadet","Diglett","Gulpin","Pawmo","Floragato"]
+          },
+          "bans": {
+            "Jordi": ["Pelipper"],
+            "Josep": []
+          },
+          "muertes": [
+            "Rockruff(Eudald) 💀 Sudowoodo(Jordi)",
+            "Charcadet(Eudald) 💀 Corvisquire(Jordi)",
+            "Diglett(Eudald) 💀 Fidough(Jordi)",
+            "Fidough(Jordi) 💀 Gulpin(Eudald)",
+            "Chansey(Jordi) 💀 Pawmo(Eudald)",
+            "Fletchinder(Jordi) 💀 Gulpin(Eudald)",
+            "Gulpin(Eudald) 💀 Luxio(Jordi)",
+            "Luxio(Jordi) 💀 Floragato(Eudald)",
+            "Floragato(Eudald) 💀 Corvisquire(Jordi)",
+            "Corvisquire(Jordi) 💀 Pawmo(Eudald)",
+            "Sudowoodo(Jordi) 💀 Pawmo(Eudald)"
+          ]
+        },
+        {
+          "jugador1": "Eudald",
+          "jugador2": "Josep",
+          "guanyador": "Josep",
+          "data": "13/07/2025",
+          "hora": "23:00",
+          "youtube": "https://www.youtube.com/embed/GcLunYRxzYo",
+          "equips": {
+            "Eudald": ["Sudowoodo","Fidough","Chansey","Corvisquire","Luxio"],
+            "Josep": ["Oinkologne","Toedscool","Skiploom","Pawmo","Crocalor","Kricketune"]
+          },
+          "bans": {
+            "Eudald": ["Sylveon"],
+            "Josep": []
+          },
+          "muertes": [
+            "Oinkologne(Josep) 💀 Sudowoodo(Jordi)",
+            "Sudowoodo(Jordi) 💀 Toedscool(Josep)",
+            "Fidough(Jordi) 💀 Skiploom(Josep)",
+            "Chansey(Jordi) 💀 Pawmo(Josep)",
+            "Corvisquire(Jordi) 💀 Crocalor(Josep)",
+            "Toedscool(Josep) 💀 Luxio(Jordi)",
+            "Kricketune(Josep) 💀 Luxio(Jordi)",
+            "Crocalor(Josep) 💀 Luxio(Jordi)"
+          ]
+        },
+        {
+          "jugador1": "Jordi",
+          "jugador2": "Eudald",
+          "guanyador": "Eudald",
+          "data": "13/07/2025",
+          "hora": "23:30",
+          "youtube": "https://www.youtube.com/embed/6uAHdV7UEXw",
+          "equips": {
+            "Jordi": ["Rockruff","Psyduck","Floragato","Skiploom","Pawmo"],
+            "Eudald": ["Oinkologne","Toedscool","Kricketune","Crocalor"]
+          },
+          "bans": {
+            "Jordi": [],
+            "Eudald": []
+          },
+          "muertes": [
+            "Rockruff (Eudald) 💀 Oinkologne(Josep)",
+            "Psyduck(Eudald) 💀 Oinkologne(Josep)",
+            "Oinkologne(Josep) 💀 Floragato(Eudald)",
+            "Toedscool(Josep) 💀 Skiploom(Eudald)",
+            "Kircketune(Josep) 💀 Floragato(Eudald)",
+            "Floragato(Eudald) 💀 Crocalor(Josep)",
+            "Pawmo(Eudald) 💀 Crocalor(Josep)",
+            "Crocalor(Josep) 💀 Skiploom(Eudald)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/jornades.html
+++ b/jornades.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Pokemon Torneig - Jornades</title>
+<link rel="stylesheet" href="css/style.css" />
+<style>
+  :root {
+    --primary: #ffcb05;
+    --secondary: #3b4cca;
+    --shadow: 0 4px 10px rgba(0,0,0,0.1);
+  }
+  body {font-family: system-ui, sans-serif;}
+  .jornades-container {
+    max-width: 1200px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+  }
+  .jornada {
+    background: white;
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    margin-bottom: 2rem;
+    overflow: hidden;
+  }
+  .jornada h2 {
+    background: var(--primary);
+    margin: 0;
+    padding: 1rem;
+    color: #212529;
+    font-size: 1.5rem;
+  }
+  .match-card {
+    padding: 1rem;
+    border-bottom: 1px solid #eee;
+  }
+  .match-card:last-child {border-bottom: none;}
+  .teams {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+  }
+  .team {text-align: center;}
+  .team .trainer {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 50%;
+    box-shadow: var(--shadow);
+    margin-bottom: 0.5rem;
+  }
+  .pokemon-team img {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+    margin: 0.2rem;
+  }
+  .vs {
+    font-weight: bold;
+    font-size: 1.2rem;
+  }
+  .details {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+  }
+  .winner {color: #d4af37; font-weight: bold;}
+  .video {text-decoration: none; color: var(--secondary);}
+  @media (max-width: 768px) {
+    .teams {flex-direction: column;}
+    .vs {margin: 0.5rem 0;}
+    .details {flex-direction: column; gap: 0.5rem;}
+  }
+</style>
+</head>
+<body>
+<header style="text-align:center; padding:1rem; background:#fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1);">
+  <img src="images.jpeg" alt="Pokémon Escarlata i Púrpura" style="max-width:100%; height:auto; border-radius:12px;" />
+</header>
+
+<nav id="main-nav"></nav>
+
+<main id="jornades" class="jornades-container"></main>
+
+<script type="module">
+import { setupNav } from './nav-component.js';
+setupNav();
+
+async function loadJornades(){
+  const [jornadesData, trainersData] = await Promise.all([
+    fetch('data/jornades.json').then(r=>r.json()),
+    fetch('data.json').then(r=>r.json())
+  ]);
+  const entrenadors = trainersData.entrenadores;
+  const container = document.getElementById('jornades');
+  jornadesData.jornades.forEach(jornada => {
+    const jornadaSection = document.createElement('section');
+    jornadaSection.className = 'jornada';
+    jornadaSection.innerHTML = `<h2>Jornada ${jornada.numero} - ${jornada.nom}</h2>`;
+    jornada.combats.forEach(combat => {
+      const card = document.createElement('div');
+      card.className = 'match-card';
+      const t1 = entrenadors[combat.jugador1.toLowerCase()];
+      const t2 = entrenadors[combat.jugador2.toLowerCase()];
+      const team1Imgs = (combat.equips[combat.jugador1]||[]).map(p=>{
+        const pk = t1.equipo.find(e=>e.nombre===p);
+        return pk ? `<img src="${pk.imagen}" alt="${p}">` : '';
+      }).join('');
+      const team2Imgs = (combat.equips[combat.jugador2]||[]).map(p=>{
+        const pk = t2.equipo.find(e=>e.nombre===p);
+        return pk ? `<img src="${pk.imagen}" alt="${p}">` : '';
+      }).join('');
+      card.innerHTML = `
+        <div class="teams">
+          <div class="team">
+            <img class="trainer" src="${t1.imagen}" alt="${combat.jugador1}">
+            <div>${combat.jugador1}</div>
+            <div class="pokemon-team">${team1Imgs}</div>
+          </div>
+          <span class="vs">vs</span>
+          <div class="team">
+            <img class="trainer" src="${t2.imagen}" alt="${combat.jugador2}">
+            <div>${combat.jugador2}</div>
+            <div class="pokemon-team">${team2Imgs}</div>
+          </div>
+        </div>
+        <div class="details">
+          <span class="date">${combat.data} - ${combat.hora}</span>
+          <span class="winner">🏆 ${combat.guanyador}</span>
+          <a class="video" href="${combat.youtube}" target="_blank">Vídeo</a>
+        </div>`;
+      jornadaSection.appendChild(card);
+    });
+    container.appendChild(jornadaSection);
+  });
+}
+loadJornades();
+</script>
+</body>
+</html>

--- a/nav-component.js
+++ b/nav-component.js
@@ -19,6 +19,7 @@ export function renderNav(currentPage = '') {
             ]
         },
         { href: "combates.html", text: "Combats" },
+        { href: "jornades.html", text: "Jornades" },
         {
             text: "Tests",
             subItems: [ { href: "clasificacion-stat.html", text: "Stats"}


### PR DESCRIPTION
## Summary
- add new `jornades.html` to display matchdays with trainer and Pokémon images
- link new matchday page from site navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a461accb4483269cfcaf0a37242310